### PR TITLE
update appstream metadata install location

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,9 +15,9 @@ To uninstall, remove files and directories
     .../bin/nfoview
     .../lib/python3.*/dist-packages/nfoview*
     .../lib/python3.*/site-packages/nfoview*
-    .../share/appdata/nfoview.appdata.xml
     .../share/applications/nfoview.desktop
     .../share/icons/hicolor/*/apps/nfoview.*
     .../share/locale/*/LC_MESSAGES/nfoview.mo
     .../share/man/man1/nfoview.1
+    .../share/metainfo/nfoview.appdata.xml
     .../share/nfoview/

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,4 @@
+NFO Viewer 1.23
+===============
+
+* [x] Install appdata XML file under /usr/share/metainfo (#12)

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ class InstallData(install_data):
         """Return a tuple for the translated appdata file."""
         path = os.path.join("data", "nfoview.appdata.xml")
         run_or_exit("intltool-merge -x po {}.in {}".format(path, path))
-        return ("share/appdata", (path,))
+        return ("share/metainfo", (path,))
 
     def __get_desktop_file(self):
         """Return a tuple for the translated desktop file."""


### PR DESCRIPTION
because apparently, "appdata" is a legacy location.

See section 2.1.2 at https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html and https://lintian.debian.org/tags/appstream-metadata-in-legacy-location.html