### PR TITLE
Sort input file list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ class InstallData(install_data):
 
     def __generate_linguas(self):
         """Generate LINGUAS file needed by msgfmt."""
-        linguas = glob.glob("po/*.po")
+        linguas = sorted(glob.glob("po/*.po"))
         linguas = [x.split(os.sep)[1] for x in linguas]
         linguas = [x.split(".")[0] for x in linguas]
         with open("po/LINGUAS", "w") as f:


### PR DESCRIPTION
so that .desktop and appdata.xml files build in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.