### PR TITLE
Sort .po input file list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,7 @@ class InstallData(install_data):
     def run(self):
         """Install data files after translating them."""
         self.__generate_linguas()
-        for po_file in glob.glob("po/*.po"):
+        for po_file in sorted(glob.glob("po/*.po")):
             if freezing: continue
             self.data_files.append(self.__get_mo_file(po_file))
         self.data_files.append(self.__get_appdata_file())


### PR DESCRIPTION
Sort .po input file list
so that nfoview.desktop and nfoview.appdata.xml builds in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.

I thought, I had tested that #13 fixed all of it, but there was still variation in nfoview.appdata.xml now that went away with this patch.